### PR TITLE
Allow underscores in alter table and column names.

### DIFF
--- a/mysqlparse/grammar/alter_table.py
+++ b/mysqlparse/grammar/alter_table.py
@@ -11,7 +11,7 @@ from mysqlparse.grammar.utils import stripQuotes, defaultValue
 # PARTIAL PARSERS
 #
 
-_column_name = Word(alphanums + "`").setParseAction(stripQuotes)
+_column_name = Word(alphanums + "`_").setParseAction(stripQuotes)
 _add = CaselessKeyword("ADD").setParseAction(replaceWith("ADD COLUMN")).setResultsName("alter_action")
 _add_column = CaselessKeyword("ADD COLUMN").setResultsName("alter_action")
 _column_position = Optional(
@@ -44,7 +44,7 @@ _ignore = Optional(
 alter_table_syntax = Forward()
 alter_table_syntax <<= (
     CaselessKeyword("ALTER").setResultsName("statement_type") + _ignore + Suppress(Optional(CaselessKeyword("TABLE"))) +
-    Word(alphanums + "`").setResultsName("table_name") +
+    Word(alphanums + "`_").setResultsName("table_name") +
     delimitedList(Group(_alter_specification_syntax).setResultsName("alter_specification", listAllMatches=True)) +
     Suppress(Optional(";"))
 )

--- a/tests/grammar/test_alter_table.py
+++ b/tests/grammar/test_alter_table.py
@@ -10,27 +10,27 @@ class AlterTableSyntaxTest(unittest.TestCase):
 
     def test_alter_table_add(self):
         statement = alter_table_syntax.parseString("""
-        ALTER IGNORE TABLE test ADD col0 BIT(8) NOT NULL DEFAULT 0 FIRST,
-            ADD col1 LONGTEXT NOT NULL,
-            ADD col2 VARCHAR(200) NULL,
-            ADD col3 BIT(8) AFTER col0;
+        ALTER IGNORE TABLE test_test ADD col_no0 BIT(8) NOT NULL DEFAULT 0 FIRST,
+            ADD col_no1 LONGTEXT NOT NULL,
+            ADD col_no2 VARCHAR(200) NULL,
+            ADD col_no3 BIT(8) AFTER col0;
         """)
 
         self.assertTrue(statement.ignore)
         self.assertEquals(statement.statement_type, 'ALTER')
-        self.assertEquals(statement.table_name, 'test')
-        self.assertEquals(statement.alter_specification[0].column_name, 'col0')
+        self.assertEquals(statement.table_name, 'test_test')
+        self.assertEquals(statement.alter_specification[0].column_name, 'col_no0')
         self.assertEquals(statement.alter_specification[0].column_position, 'FIRST')
-        self.assertEquals(statement.alter_specification[1].column_name, 'col1')
+        self.assertEquals(statement.alter_specification[1].column_name, 'col_no1')
         self.assertEquals(statement.alter_specification[1].column_position, 'LAST')
-        self.assertEquals(statement.alter_specification[2].column_name, 'col2')
+        self.assertEquals(statement.alter_specification[2].column_name, 'col_no2')
         self.assertEquals(statement.alter_specification[2].column_position, 'LAST')
-        self.assertEquals(statement.alter_specification[3].column_name, 'col3')
+        self.assertEquals(statement.alter_specification[3].column_name, 'col_no3')
         self.assertEquals(statement.alter_specification[3].column_position, 'col0')
 
     def test_alter_table_add_column(self):
         statement = alter_table_syntax.parseString("""
-        ALTER TABLE test ADD COLUMN col0 BIT(8) NOT NULL DEFAULT 0 FIRST,
+        ALTER TABLE test_test ADD COLUMN col0 BIT(8) NOT NULL DEFAULT 0 FIRST,
             ADD COLUMN col1 LONGTEXT NOT NULL,
             ADD COLUMN col2 VARCHAR(200) NULL,
             ADD COLUMN col3 BIT(8) AFTER col0;
@@ -38,7 +38,7 @@ class AlterTableSyntaxTest(unittest.TestCase):
 
         self.assertFalse(statement.ignore)
         self.assertEquals(statement.statement_type, 'ALTER')
-        self.assertEquals(statement.table_name, 'test')
+        self.assertEquals(statement.table_name, 'test_test')
         self.assertEquals(statement.alter_specification[0].column_name, 'col0')
         self.assertEquals(statement.alter_specification[0].column_position, 'FIRST')
         self.assertEquals(statement.alter_specification[1].column_name, 'col1')
@@ -50,7 +50,7 @@ class AlterTableSyntaxTest(unittest.TestCase):
 
     def test_alter_table_add_column_mixed(self):
         statement = alter_table_syntax.parseString("""
-        ALTER TABLE test ADD col0 BIT(8) NOT NULL DEFAULT 0 FIRST,
+        ALTER TABLE test_test ADD col0 BIT(8) NOT NULL DEFAULT 0 FIRST,
             ADD COLUMN col1 LONGTEXT NOT NULL,
             ADD COLUMN col2 VARCHAR(200) NULL,
             ADD col3 BIT(8) AFTER col0;
@@ -58,7 +58,7 @@ class AlterTableSyntaxTest(unittest.TestCase):
 
         self.assertFalse(statement.ignore)
         self.assertEquals(statement.statement_type, 'ALTER')
-        self.assertEquals(statement.table_name, 'test')
+        self.assertEquals(statement.table_name, 'test_test')
         self.assertEquals(statement.alter_specification[0].column_name, 'col0')
         self.assertEquals(statement.alter_specification[0].column_position, 'FIRST')
         self.assertEquals(statement.alter_specification[1].column_name, 'col1')


### PR DESCRIPTION
This is sort of poor mans quick version, ideally column names and table names should probably share the same type of parser that actually enforces the back-quotes properly, not anywhere.