### PR TITLE
A little tidy up

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -10,4 +10,4 @@ Development Lead
 Contributors
 ------------
 
-None yet. Why not be the first?
+* Adam Johnson <me@adamj.eu>

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,11 +1,6 @@
-[bumpversion]
-current_version = 1.0.0
-commit = True
-tag = True
-
-[bumpversion:file:setup.py]
-
-[bumpversion:file:mysqlparse/__init__.py]
+[flake8]
+max-line-length = 130
+ignore = F403
 
 [wheel]
 universal = 1

--- a/setup.py
+++ b/setup.py
@@ -1,18 +1,16 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-from setuptools import setup
+from setuptools import find_packages, setup
 
 
 with open('README.rst') as readme_file:
     readme = readme_file.read()
 
 requirements = [
-    # TODO: put package requirements here
     'pyparsing',
 ]
 
 test_requirements = [
-    # TODO: put testing requirements here
     'pyparsing',
 ]
 
@@ -24,10 +22,7 @@ setup(
     author="Julius Seporaitis",
     author_email='julius@seporaitis.net',
     url='https://github.com/seporaitis/mysqlparse',
-    packages=[
-        'mysqlparse',
-        'mysqlparse.grammar',
-    ],
+    packages=find_packages(exclude=['tests', 'tests.*']),
     package_dir={
         'mysqlparse': 'mysqlparse',
         'mysqlparse.grammar': 'mysqlparse/grammar'
@@ -47,6 +42,7 @@ setup(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
     ],
     test_suite='tests',
     tests_require=test_requirements

--- a/tox.ini
+++ b/tox.ini
@@ -4,12 +4,7 @@ envlist = py27, py33, py34, py35, lint
 [testenv]
 commands = python setup.py test
 
-; If you want to make tox run the tests with the same versions, create a
-; requirements.txt with the pinned versions and uncomment the following lines:
-; deps =
-;     -r{toxinidir}/requirements.txt
-
 [testenv:lint]
 deps =
-    flake8==2.5.0
-commands=flake8 mysqlparse tests --max-line-length=130 --ignore=F403
+    flake8==2.5.4
+commands=flake8 mysqlparse tests


### PR DESCRIPTION
* Guessing you're not using bumpversion, remove its config
* Move flake8 config to `setup.cfg` - this allows contributors' editors to pull your custom flake8 settings
* Use `find_packages` in `setup.py` to avoid packaging mishaps
* Use latest `flake8`