### PR TITLE
Remove `defaultValue` parse action.

### DIFF
--- a/mysqlparse/grammar/alter_table.py
+++ b/mysqlparse/grammar/alter_table.py
@@ -4,7 +4,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 from pyparsing import *
 
 from mysqlparse.grammar.column_definition import column_definition_syntax
-from mysqlparse.grammar.utils import stripQuotes, defaultValue
+from mysqlparse.grammar.utils import stripQuotes
 
 
 #
@@ -15,9 +15,10 @@ _column_name = Word(alphanums + "`_").setParseAction(stripQuotes)
 _add = CaselessKeyword("ADD").setParseAction(replaceWith("ADD COLUMN")).setResultsName("alter_action")
 _add_column = CaselessKeyword("ADD COLUMN").setResultsName("alter_action")
 _column_position = Optional(
-    Or([CaselessKeyword("FIRST"), Suppress(CaselessKeyword("AFTER")) + _column_name])
-).setParseAction(defaultValue("LAST")).setResultsName("column_position")
-_last_column = Empty().setParseAction(defaultValue("LAST")).setResultsName("column_position")
+    Or([CaselessKeyword("FIRST"), Suppress(CaselessKeyword("AFTER")) + _column_name]),
+    default="LAST"
+).setResultsName("column_position")
+_last_column = Empty().setParseAction(lambda toks: ["LAST"]).setResultsName("column_position")
 
 _alter_specification_syntax = Forward()
 _alter_specification_syntax <<= (
@@ -31,8 +32,9 @@ _alter_specification_syntax <<= (
 )
 
 _ignore = Optional(
-    CaselessKeyword("IGNORE").setParseAction(replaceWith(True))
-).setParseAction(defaultValue(False)).setResultsName("ignore")
+    CaselessKeyword("IGNORE").setParseAction(replaceWith(True)),
+    default=False,
+).setResultsName("ignore")
 
 
 #

--- a/mysqlparse/grammar/utils.py
+++ b/mysqlparse/grammar/utils.py
@@ -12,19 +12,3 @@ def stripQuotes(s, loc, toks):
 
     """
     return [t.strip("'") for t in toks]
-
-
-def defaultValue(value):
-    """Return a default value.
-
-    Useful when `Optional` does not match, but some value should still
-    be set in `ParseResult`.
-
-    """
-    def _default(toks):
-        if not toks:
-            return [value]
-        if len(toks) == 1 and not toks[0]:
-            return [value]
-
-    return _default


### PR DESCRIPTION
`pyparsing.Optional` has a parameter `default` which serves the same purpose.