### PR TITLE
Improve `NULL` handling.

### DIFF
--- a/mysqlparse/grammar/column_definition.py
+++ b/mysqlparse/grammar/column_definition.py
@@ -16,7 +16,7 @@ _nullable = Or([
 ])
 _default = (
     Suppress(CaselessKeyword("DEFAULT")) +
-    Or([Word(nums), QuotedString("'")]).setName("default").setResultsName("default")
+    Or([Word(nums), QuotedString("'"), CaselessKeyword("NULL")]).setName("default").setResultsName("default")
 )
 _auto_increment = CaselessKeyword("AUTO_INCREMENT").setResultsName("auto_increment").setParseAction(replaceWith(True))
 _index_type = Or([
@@ -35,7 +35,7 @@ _comment = CaselessKeyword("COMMENT") + Or([QuotedString("'"), QuotedString('"')
 column_definition_syntax = Forward()
 column_definition_syntax <<= (
     data_type_syntax +
-    Optional(_nullable).setResultsName("null") +
+    Optional(_nullable, default="implicit").setResultsName("null") +
     Optional(_default) +
     Optional(_auto_increment) +
     Optional(_index_type) +

--- a/tests/grammar/test_column_definition.py
+++ b/tests/grammar/test_column_definition.py
@@ -9,13 +9,14 @@ from mysqlparse.grammar.column_definition import column_definition_syntax
 class ColumnDefinitionSyntax(unittest.TestCase):
 
     def test_plain_field(self):
-        self.assertFalse(column_definition_syntax.parseString("VARCHAR(255)").null)
+        self.assertEqual(column_definition_syntax.parseString("VARCHAR(255)").null, 'implicit')
         self.assertFalse(column_definition_syntax.parseString("VARCHAR(255)").default)
         self.assertFalse(column_definition_syntax.parseString("VARCHAR(255)").auto_increment)
         self.assertFalse(column_definition_syntax.parseString("VARCHAR(255)").index_type)
         self.assertFalse(column_definition_syntax.parseString("VARCHAR(255)").comment)
 
     def test_nullable(self):
+        self.assertEqual(column_definition_syntax.parseString("VARCHAR(255)").null, 'implicit')
         self.assertFalse(column_definition_syntax.parseString("VARCHAR(255) NOT NULL").null)
         self.assertTrue(column_definition_syntax.parseString("VARCHAR(255) NULL").null)
 
@@ -29,47 +30,47 @@ class ColumnDefinitionSyntax(unittest.TestCase):
         self.assertFalse(column_definition_syntax.parseString("VARCHAR(255) NULL").comment)
 
     def test_default(self):
-        self.assertFalse(column_definition_syntax.parseString("VARCHAR(255) DEFAULT 'test'").null)
+        self.assertEqual(column_definition_syntax.parseString("VARCHAR(255) DEFAULT 'test'").null, 'implicit')
         self.assertEqual(column_definition_syntax.parseString("VARCHAR(255) DEFAULT 'test'").default, 'test')
         self.assertFalse(column_definition_syntax.parseString("VARCHAR(255) DEFAULT 'test'").auto_increment)
         self.assertFalse(column_definition_syntax.parseString("VARCHAR(255) DEFAULT 'test'").index_type)
         self.assertFalse(column_definition_syntax.parseString("VARCHAR(255) DEFAULT 'test'").comment)
 
     def test_auto_increment(self):
-        self.assertFalse(column_definition_syntax.parseString("INT(11) AUTO_INCREMENT").null)
+        self.assertEqual(column_definition_syntax.parseString("INT(11) AUTO_INCREMENT").null, 'implicit')
         self.assertFalse(column_definition_syntax.parseString("INT(11) AUTO_INCREMENT").default)
         self.assertTrue(column_definition_syntax.parseString("INT(11) AUTO_INCREMENT").auto_increment)
         self.assertFalse(column_definition_syntax.parseString("INT(11) AUTO_INCREMENT").index_type)
         self.assertFalse(column_definition_syntax.parseString("INT(11) AUTO_INCREMENT").comment)
 
     def test_unique_index(self):
-        self.assertFalse(column_definition_syntax.parseString("INT(11) UNIQUE").null)
+        self.assertEqual(column_definition_syntax.parseString("INT(11) UNIQUE").null, 'implicit')
         self.assertFalse(column_definition_syntax.parseString("INT(11) UNIQUE").default)
         self.assertFalse(column_definition_syntax.parseString("INT(11) UNIQUE").auto_increment)
         self.assertEqual(column_definition_syntax.parseString("INT(11) UNIQUE").index_type, 'unique_key')
         self.assertFalse(column_definition_syntax.parseString("INT(11) UNIQUE").comment)
 
-        self.assertFalse(column_definition_syntax.parseString("INT(11) UNIQUE KEY").null)
+        self.assertEqual(column_definition_syntax.parseString("INT(11) UNIQUE KEY").null, 'implicit')
         self.assertFalse(column_definition_syntax.parseString("INT(11) UNIQUE KEY").default)
         self.assertFalse(column_definition_syntax.parseString("INT(11) UNIQUE KEY").auto_increment)
         self.assertEqual(column_definition_syntax.parseString("INT(11) UNIQUE KEY").index_type, 'unique_key')
         self.assertFalse(column_definition_syntax.parseString("INT(11) UNIQUE KEY").comment)
 
     def test_primary_key(self):
-        self.assertFalse(column_definition_syntax.parseString("INT(11) KEY").null)
+        self.assertEqual(column_definition_syntax.parseString("INT(11) KEY").null, 'implicit')
         self.assertFalse(column_definition_syntax.parseString("INT(11) KEY").default)
         self.assertFalse(column_definition_syntax.parseString("INT(11) KEY").auto_increment)
         self.assertEqual(column_definition_syntax.parseString("INT(11) KEY").index_type, 'primary_key')
         self.assertFalse(column_definition_syntax.parseString("INT(11) KEY").comment)
 
-        self.assertFalse(column_definition_syntax.parseString("INT(11) PRIMARY KEY").null)
+        self.assertEqual(column_definition_syntax.parseString("INT(11) PRIMARY KEY").null, 'implicit')
         self.assertFalse(column_definition_syntax.parseString("INT(11) PRIMARY KEY").default)
         self.assertFalse(column_definition_syntax.parseString("INT(11) PRIMARY KEY").auto_increment)
         self.assertEqual(column_definition_syntax.parseString("INT(11) PRIMARY KEY").index_type, 'primary_key')
         self.assertFalse(column_definition_syntax.parseString("INT(11) PRIMARY KEY").comment)
 
     def test_comment(self):
-        self.assertFalse(column_definition_syntax.parseString("VARCHAR(255) COMMENT 'test'").null)
+        self.assertEqual(column_definition_syntax.parseString("VARCHAR(255) COMMENT 'test'").null, 'implicit')
         self.assertFalse(column_definition_syntax.parseString("VARCHAR(255) COMMENT 'test'").default)
         self.assertFalse(column_definition_syntax.parseString("VARCHAR(255) COMMENT 'test'").auto_increment)
         self.assertFalse(column_definition_syntax.parseString("VARCHAR(255) COMMENT 'test'").index_type)


### PR DESCRIPTION
- Add an option called `implicit` when neither `NULL` nor `NOT NULL` is assigned to a column.
- Allow `DEFAULT NULL`.