### PR TITLE
Some packaging tidy up

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -81,9 +81,9 @@ A short list of things that would help (from relatively easiest):
 * Add a missing test case or suggest a way to avoid so much repetition
   in tests checking the same statement, but with variations.
 
-* Suggest how to use `pyparsing` to do statement validation.
+* Suggest how to use ``pyparsing`` to do statement validation.
 
-* Maybe it is possible to generate `pyparsing` parser from the MySQL
+* Maybe it is possible to generate ``pyparsing`` parser from the MySQL
   source code?
 
 * Add ability to unparse the parse (sub)trees back into valid SQL.

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,7 @@
+[bdist_wheel]
+universal = 1
+
 [flake8]
 max-line-length = 130
 ignore = F403
 
-[wheel]
-universal = 1

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,10 @@
 [tox]
-envlist = py27, py33, py34, py35, lint
+envlist = py27, py33, py34, py35, py35-lint
 
 [testenv]
 commands = python setup.py test
 
-[testenv:lint]
+[testenv:py35-lint]
 deps =
     flake8==2.5.4
 commands=flake8 mysqlparse tests


### PR DESCRIPTION
* Non-deprecated section name for wheels is `bdist_wheel`
* Make `tox` environment for linting use a fixed version of python - otherwise the build is non-deterministic as `tox` will run it with whichever version of Python it was installed with
* Corret some syntax highlighting in README