### PR TITLE
New release `0.1.6`

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,18 @@
 History
 -------
 
+PENDING
+-------
+
+* (Insert new release notes below this line)
+
+
+0.1.6 (2017-06-16)
+------------------
+
+* Add support for ``ALTER TABLE .. CHANGE COLUMN`` statements (contributed by @jgysland)
+
+
 0.1.5 (2016-08-23)
 ------------------
 

--- a/mysqlparse/__init__.py
+++ b/mysqlparse/__init__.py
@@ -7,7 +7,7 @@ from mysqlparse.grammar.sql_file import sql_file_syntax
 
 __author__ = 'Julius Seporaitis'
 __email__ = 'julius@seporaitis.net'
-__version__ = '0.1.5'
+__version__ = '0.1.6'
 
 
 def parse(file_or_string):


### PR DESCRIPTION
The `HISTORY.rst` is different from pypy because I constantly forget ReStructuredText is not Markdown.