### PR TITLE
Add support for database names in alter table statements.

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,6 +6,7 @@ History
 PENDING
 -------
 
+* Add support for database names (contributed by @jgysland)
 * (Insert new release notes below this line)
 
 

--- a/mysqlparse/grammar/alter_table.py
+++ b/mysqlparse/grammar/alter_table.py
@@ -11,6 +11,11 @@ from mysqlparse.grammar.utils import stripQuotes
 # PARTIAL PARSERS
 #
 
+_database_name = (Optional(Word(alphanums + "`_") + FollowedBy('.') +
+                           Suppress('.'), default=None)
+                  .setResultsName("database_name")
+                  .setParseAction(lambda toks: toks[0]))
+
 # ADD COLUMN
 _column_name = Word(alphanums + "`_").setParseAction(stripQuotes)
 _add = CaselessKeyword("ADD").setParseAction(replaceWith("ADD COLUMN")).setResultsName("alter_action")
@@ -144,10 +149,6 @@ _ignore = Optional(
 # Source: http://dev.mysql.com/doc/refman/5.7/en/alter-table.html
 #
 
-_database_name = (Optional(Word(alphanums + "`_") + FollowedBy('.') +
-                           Suppress('.'), default=None)
-                  .setResultsName("database_name")
-                  .setParseAction(lambda toks: toks[0]))
 alter_table_syntax = Forward()
 alter_table_syntax <<= (
     CaselessKeyword("ALTER").setResultsName("statement_type") + _ignore + Suppress(Optional(CaselessKeyword("TABLE"))) +

--- a/mysqlparse/grammar/alter_table.py
+++ b/mysqlparse/grammar/alter_table.py
@@ -144,10 +144,14 @@ _ignore = Optional(
 # Source: http://dev.mysql.com/doc/refman/5.7/en/alter-table.html
 #
 
+_database_name = (Optional(Word(alphanums + "`_") + FollowedBy('.') +
+                           Suppress('.'), default=None)
+                  .setResultsName("database_name")
+                  .setParseAction(lambda toks: toks[0]))
 alter_table_syntax = Forward()
 alter_table_syntax <<= (
     CaselessKeyword("ALTER").setResultsName("statement_type") + _ignore + Suppress(Optional(CaselessKeyword("TABLE"))) +
-    Word(alphanums + "`_").setResultsName("table_name") +
+    _database_name + Word(alphanums + "`_").setResultsName("table_name") +
     delimitedList(Group(_alter_specification_syntax).setResultsName("alter_specification", listAllMatches=True)) +
     Suppress(Optional(";"))
 )

--- a/tests/grammar/test_alter_table.py
+++ b/tests/grammar/test_alter_table.py
@@ -380,3 +380,31 @@ class AlterTableDropSyntaxTest(unittest.TestCase):
         self.assertEqual(statement.alter_specification[4].index_name, 'idx_no1')
         self.assertEqual(statement.alter_specification[5].alter_action, 'DROP FOREIGN KEY')
         self.assertEqual(statement.alter_specification[5].fk_symbol, 'fk_no0')
+
+
+class AlterTableDatabaseNameTest(unittest.TestCase):
+
+    def test_alter_table_database_name(self):
+        statement = alter_table_syntax.parseString("""
+        ALTER IGNORE TABLE test_db.test_test CHANGE col_no0 col_0 BIT(8) NOT NULL DEFAULT 0 FIRST,
+            CHANGE col_no1 col_1 LONGTEXT NOT NULL,
+            CHANGE col_no2 col_2 VARCHAR(200) NULL,
+            CHANGE col_no3 col_3 BIT(8) AFTER col0;
+        """)
+
+        self.assertTrue(statement.ignore)
+        self.assertEqual(statement.statement_type, 'ALTER')
+        self.assertEqual(statement.database_name, 'test_db')
+        self.assertEqual(statement.table_name, 'test_test')
+        self.assertEqual(statement.alter_specification[0].column_name, 'col_no0')
+        self.assertEqual(statement.alter_specification[0].new_column_name, 'col_0')
+        self.assertEqual(statement.alter_specification[0].column_position, 'FIRST')
+        self.assertEqual(statement.alter_specification[1].column_name, 'col_no1')
+        self.assertEqual(statement.alter_specification[1].new_column_name, 'col_1')
+        self.assertEqual(statement.alter_specification[1].column_position, 'LAST')
+        self.assertEqual(statement.alter_specification[2].column_name, 'col_no2')
+        self.assertEqual(statement.alter_specification[2].new_column_name, 'col_2')
+        self.assertEqual(statement.alter_specification[2].column_position, 'LAST')
+        self.assertEqual(statement.alter_specification[3].column_name, 'col_no3')
+        self.assertEqual(statement.alter_specification[3].new_column_name, 'col_3')
+        self.assertEqual(statement.alter_specification[3].column_position, 'col0')


### PR DESCRIPTION
Find database names in statements, a la "my_db.my_table".

Updated contribution from #39 