### PR TITLE
Add full support for MySQL identifiers

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -7,6 +7,7 @@ PENDING
 -------
 
 * Add support for database names (contributed by @jgysland)
+* Add explicit support for MySQL identifiers
 * (Insert new release notes below this line)
 
 

--- a/mysqlparse/grammar/identifier.py
+++ b/mysqlparse/grammar/identifier.py
@@ -1,0 +1,20 @@
+# -*- encoding:utf-8 -*-
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+from pyparsing import *
+
+from mysqlparse.grammar.utils import stripQuotes
+
+
+#
+# SCHEMA OBJECT NAMES (IDENTIFIERS)
+#
+# Source: https://dev.mysql.com/doc/refman/5.7/en/identifiers.html
+#
+
+identifier_syntax = Or([
+    Word(alphanums + "_$"),
+    QuotedString('"'),
+    QuotedString("`"),
+    QuotedString("'")
+]).setParseAction(stripQuotes)

--- a/tests/grammar/test_identifier.py
+++ b/tests/grammar/test_identifier.py
@@ -1,0 +1,51 @@
+# -*- encoding:utf-8 -*-
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import unittest
+
+from pyparsing import ParseException
+
+from mysqlparse.grammar.identifier import identifier_syntax
+
+
+class IdentifierSyntaxTest(unittest.TestCase):
+
+    def test_valid_unquoted(self):
+        statement = identifier_syntax.parseString("valid_$name")
+        self.assertEqual(statement[0], "valid_$name")
+
+    def test_valid_backquoted(self):
+        statement = identifier_syntax.parseString("`valid_$name`")
+        self.assertEqual(statement[0], "valid_$name")
+
+    def test_valid_singlequoted(self):
+        statement = identifier_syntax.parseString("'valid_$name'")
+        self.assertEqual(statement[0], "valid_$name")
+
+    def test_valid_doublequoted(self):
+        statement = identifier_syntax.parseString('"valid_$name"')
+        self.assertEqual(statement[0], "valid_$name")
+
+    def test_valid_backquoted_nonstandard(self):
+        statement = identifier_syntax.parseString("`valid $name`")
+        self.assertEqual(statement[0], "valid $name")
+
+    def test_valid_singlequoted_nonstandard(self):
+        statement = identifier_syntax.parseString("'valid $name'")
+        self.assertEqual(statement[0], "valid $name")
+
+    def test_valid_doublequoted_nonstandard(self):
+        statement = identifier_syntax.parseString('"valid $name"')
+        self.assertEqual(statement[0], "valid $name")
+
+    def test_invalid_missing_backquote(self):
+        with self.assertRaises(ParseException):
+            identifier_syntax.parseString("`valid $name")
+
+    def test_invalid_missing_singlequote(self):
+        with self.assertRaises(ParseException):
+            identifier_syntax.parseString("'valid $name")
+
+    def test_invalid_missing_doublequote(self):
+        with self.assertRaises(ParseException):
+            identifier_syntax.parseString('"valid $name')


### PR DESCRIPTION
As @adamchainz pointed out in #39 - MySQL identifiers [support more characters](https://dev.mysql.com/doc/refman/5.7/en/identifiers.html) than only alphanums and underscore:

> Identifiers are converted to Unicode internally. They may contain these characters:
> * Permitted characters in unquoted identifiers:
>   * ASCII: [0-9,a-z,A-Z$_] (basic Latin letters, digits 0-9, dollar, underscore)
>   * Extended: U+0080 .. U+FFFF 
> * Permitted characters in quoted identifiers include the full Unicode Basic Multilingual Plane (BMP), except U+0000:
>   * ASCII: U+0001 .. U+007F
>   * Extended: U+0080 .. U+FFFF 
> * ASCII NUL (U+0000) and supplementary characters (U+10000 and higher) are not permitted in quoted or unquoted identifiers.
> * Identifiers may begin with a digit but unless quoted may not consist solely of digits.
> * Database, table, and column names cannot end with space characters. 


This could be a two stage change (should be easier to implement):
* "Permitted characters in unquoted identifiers" (as per above)
* "Permitted characters in quoted identifiers" (as per above)


P.S. I am little worried about Py2 support, `pyparsing` and unicode characters, but I guess covering the base without them would be good enough MVP, and anything else could come in as a separate, but still welcome, contribution.