### PR TITLE
Allow positional arguments with tox command

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -2,9 +2,9 @@
 envlist = py27, py33, py34, py35, py35-lint
 
 [testenv]
-commands = python setup.py test
+commands = python setup.py test {posargs}
 
 [testenv:py35-lint]
 deps =
     flake8==2.5.4
-commands=flake8 mysqlparse tests
+commands=flake8 mysqlparse tests {posargs}


### PR DESCRIPTION
Allows running individual tests, e.g.:

```shell
tox -epy35 -- -s tests.grammar.test_column_definition
```