### PR TITLE
Make `mysqlparse` safe to import without dependencies installed.

### DIFF
--- a/mysqlparse/__init__.py
+++ b/mysqlparse/__init__.py
@@ -3,8 +3,6 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import six
 
-from mysqlparse.grammar.sql_file import sql_file_syntax
-
 __author__ = 'Julius Seporaitis'
 __email__ = 'julius@seporaitis.net'
 __version__ = '0.1.6'
@@ -19,6 +17,8 @@ def parse(file_or_string):
     Returns:
         ParseResults: instance of pyparsing parse results.
     """
+    from mysqlparse.grammar.sql_file import sql_file_syntax
+
     if hasattr(file_or_string, 'read') and hasattr(file_or_string.read, '__call__'):
         return sql_file_syntax.parseString(file_or_string.read())
     elif isinstance(file_or_string, six.string_types):

--- a/requirements_docs.txt
+++ b/requirements_docs.txt
@@ -1,4 +1,2 @@
-pyparsing==2.2.0
-six=1.10.0
 sphinx==1.3.5
 sphinx-autobuild==0.6.0

--- a/requirements_docs.txt
+++ b/requirements_docs.txt
@@ -1,2 +1,4 @@
+pyparsing==2.2.0
+six=1.10.0
 sphinx==1.3.5
 sphinx-autobuild==0.6.0


### PR DESCRIPTION
Required so that `readthedocs.io` build can succeed.