### PR TITLE
support RENAME TABLE, DROP TABLE, ALTER TABLE RENAME

### DIFF
--- a/mysqlparse/grammar/drop_table.py
+++ b/mysqlparse/grammar/drop_table.py
@@ -1,0 +1,42 @@
+# -*- encoding:utf-8 -*-
+from __future__ import (
+    absolute_import,
+    division,
+    print_function,
+    unicode_literals
+    )
+
+from pyparsing import (
+    CaselessKeyword,
+    Group,
+    OneOrMore,
+    Optional,
+    delimitedList,
+    replaceWith
+    )
+
+from mysqlparse.grammar.identifier import (
+    database_name_syntax,
+    identifier_syntax
+    )
+
+_drop_type = CaselessKeyword("TABLE").setResultsName("drop_type")
+
+_temporary = Optional(
+    CaselessKeyword("TEMPORARY").setParseAction(replaceWith(True)),
+    default=False,
+).setResultsName("temporary")
+
+_if_not_exists = Optional(
+    CaselessKeyword("IF EXISTS").setParseAction(replaceWith(True)),
+    default=False,
+).setResultsName("if_exists")
+
+drop_table_syntax = (
+    CaselessKeyword("DROP").setResultsName("statement_type") + _temporary +
+    CaselessKeyword("TABLE") + _if_not_exists + delimitedList(
+        OneOrMore(Group(database_name_syntax.setResultsName("database_name") +
+                        identifier_syntax.setResultsName("table_name"))
+                  .setResultsName("dropped", listAllMatches=True))
+        )
+    )

--- a/mysqlparse/grammar/identifier.py
+++ b/mysqlparse/grammar/identifier.py
@@ -18,3 +18,7 @@ identifier_syntax = Or([
     QuotedString("`"),
     QuotedString("'")
 ]).setParseAction(stripQuotes)
+
+database_name_syntax = (Optional(identifier_syntax + FollowedBy('.') +
+                                 Suppress('.'), default=None)
+                        .setParseAction(lambda s, l, toks: toks[0]))

--- a/mysqlparse/grammar/rename_table.py
+++ b/mysqlparse/grammar/rename_table.py
@@ -1,0 +1,49 @@
+# -*- encoding:utf-8 -*-
+from __future__ import (
+    absolute_import,
+    division,
+    print_function,
+    unicode_literals
+    )
+
+from pyparsing import (
+    CaselessKeyword,
+    Group,
+    OneOrMore,
+    Optional,
+    Suppress,
+    delimitedList
+    )
+
+from mysqlparse.grammar.identifier import (
+    identifier_syntax,
+    database_name_syntax
+    )
+
+#
+# PARTIAL PARSERS
+#
+
+_tables_renamed = (
+    database_name_syntax.setResultsName("old_database_name") +
+    identifier_syntax.setResultsName("old_table_name") +
+    Suppress(CaselessKeyword("TO")) +
+    database_name_syntax.setResultsName("new_database_name") +
+    database_name_syntax + identifier_syntax.setResultsName("new_table_name")
+    )
+
+#
+# RENAME TABLE SYNTAX
+#
+# Source: https://dev.mysql.com/doc/refman/5.7/en/rename-table.html
+#
+
+rename_table_syntax = (
+    CaselessKeyword("RENAME").setResultsName("statement_type") +
+    Suppress(Optional(CaselessKeyword("TABLE"))) +
+    delimitedList(
+        OneOrMore(Group(_tables_renamed)
+                  .setResultsName("table_renamed", listAllMatches=True))
+        ) +
+    Suppress(Optional(";"))
+)

--- a/mysqlparse/grammar/sql_file.py
+++ b/mysqlparse/grammar/sql_file.py
@@ -5,6 +5,7 @@ from pyparsing import *
 
 from mysqlparse.grammar.alter_table import alter_table_syntax
 from mysqlparse.grammar.create_table import create_table_syntax
+from mysqlparse.grammar.rename_table import rename_table_syntax
 
 
 sql_file_syntax = (
@@ -13,14 +14,16 @@ sql_file_syntax = (
             SkipTo(
                 Or([
                     CaselessKeyword("ALTER"),
-                    CaselessKeyword("CREATE")
+                    CaselessKeyword("CREATE"),
+                    CaselessKeyword("RENAME")
                 ])
             )
         ) +
         Group(
             Or([
                 alter_table_syntax,
-                create_table_syntax
+                create_table_syntax,
+                rename_table_syntax
             ])
         ).setResultsName("statements", listAllMatches=True)
     )

--- a/mysqlparse/grammar/sql_file.py
+++ b/mysqlparse/grammar/sql_file.py
@@ -6,6 +6,7 @@ from pyparsing import *
 from mysqlparse.grammar.alter_table import alter_table_syntax
 from mysqlparse.grammar.create_table import create_table_syntax
 from mysqlparse.grammar.rename_table import rename_table_syntax
+from mysqlparse.grammar.drop_table import drop_table_syntax
 
 
 sql_file_syntax = (
@@ -15,7 +16,8 @@ sql_file_syntax = (
                 Or([
                     CaselessKeyword("ALTER"),
                     CaselessKeyword("CREATE"),
-                    CaselessKeyword("RENAME")
+                    CaselessKeyword("RENAME"),
+                    CaselessKeyword("DROP"),
                 ])
             )
         ) +
@@ -23,7 +25,8 @@ sql_file_syntax = (
             Or([
                 alter_table_syntax,
                 create_table_syntax,
-                rename_table_syntax
+                rename_table_syntax,
+                drop_table_syntax
             ])
         ).setResultsName("statements", listAllMatches=True)
     )

--- a/tests/grammar/test_alter_table.py
+++ b/tests/grammar/test_alter_table.py
@@ -408,3 +408,61 @@ class AlterTableDatabaseNameTest(unittest.TestCase):
         self.assertEqual(statement.alter_specification[3].column_name, 'col_no3')
         self.assertEqual(statement.alter_specification[3].new_column_name, 'col_3')
         self.assertEqual(statement.alter_specification[3].column_position, 'col0')
+
+
+class AlterTableRenameKeysIndexes(unittest.TestCase):
+
+    def test_rename_index(self):
+        statement = alter_table_syntax.parseString("""
+        ALTER TABLE test RENAME INDEX idx1 TO idx2;
+        """)
+
+        self.assertEqual(statement.statement_type, 'ALTER')
+        self.assertEqual(statement.table_name, 'test')
+        self.assertEqual(statement.alter_specification[0].old_index_name,
+                         'idx1')
+        self.assertEqual(statement.alter_specification[0].new_index_name,
+                         'idx2')
+
+    def test_rename_key(self):
+        statement = alter_table_syntax.parseString("""
+        ALTER TABLE test RENAME KEY key1 TO key2;
+        """)
+
+        self.assertEqual(statement.statement_type, 'ALTER')
+        self.assertEqual(statement.table_name, 'test')
+        self.assertEqual(statement.alter_specification[0].old_key_name, 'key1')
+        self.assertEqual(statement.alter_specification[0].new_key_name, 'key2')
+
+    def test_rename_mixed_index_key(self):
+        statement = alter_table_syntax.parseString("""
+        ALTER TABLE test
+            RENAME INDEX idx1 TO idx2,
+            RENAME KEY key1 TO key2;
+        """)
+
+        self.assertEqual(statement.statement_type, 'ALTER')
+        self.assertEqual(statement.table_name, 'test')
+        self.assertEqual(statement.alter_specification[0].old_index_name,
+                         'idx1')
+        self.assertEqual(statement.alter_specification[0].new_index_name,
+                         'idx2')
+        self.assertEqual(statement.alter_specification[1].old_key_name, 'key1')
+        self.assertEqual(statement.alter_specification[1].new_key_name, 'key2')
+
+
+class AlterTableRename(unittest.TestCase):
+
+    def test_rename_table(self):
+        statements = [
+            "ALTER TABLE test1 RENAME test2;",
+            "ALTER TABLE test1 RENAME TO test2;",
+            "ALTER TABLE test1 RENAME AS test2;"
+            ]
+        for statement in statements:
+            stmt = alter_table_syntax.parseString(statement)
+
+            self.assertEqual(stmt.statement_type, 'ALTER')
+            self.assertEqual(stmt.table_name, 'test1')
+            self.assertEqual(stmt.alter_specification[0].new_table_name,
+                             'test2')

--- a/tests/grammar/test_drop_table.py
+++ b/tests/grammar/test_drop_table.py
@@ -1,0 +1,63 @@
+# -*- encoding:utf-8 -*-
+from __future__ import (
+    absolute_import,
+    division,
+    print_function,
+    unicode_literals
+    )
+
+import unittest
+
+from mysqlparse.grammar.drop_table import drop_table_syntax
+
+
+class DropTableSyntaxTest(unittest.TestCase):
+
+    def test_drop_table(self):
+        statement = drop_table_syntax.parseString("""
+        DROP TABLE test;
+        """)
+
+        self.assertEqual(statement.statement_type, 'DROP')
+        self.assertFalse(statement.temporary)
+        self.assertFalse(statement.if_exists)
+        self.assertFalse(statement.dropped[0].database_name)
+        self.assertEqual(statement.dropped[0].table_name, 'test')
+
+    def test_drop_multiple_tables(self):
+        statement = drop_table_syntax.parseString("""
+        DROP TABLE test, test_db.test_table, yet_another_test_table;
+        """)
+
+        self.assertEqual(statement.statement_type, 'DROP')
+        self.assertFalse(statement.temporary)
+        self.assertFalse(statement.if_exists)
+        self.assertFalse(statement.dropped[0].database_name)
+        self.assertEqual(statement.dropped[0].table_name, 'test')
+        self.assertEqual(statement.dropped[1].database_name, 'test_db')
+        self.assertEqual(statement.dropped[1].table_name, 'test_table')
+        self.assertFalse(statement.dropped[2].database_name)
+        self.assertEqual(statement.dropped[2].table_name,
+                         'yet_another_test_table')
+
+    def test_drop_temporary_table(self):
+        statement = drop_table_syntax.parseString("""
+        DROP TEMPORARY TABLE test;
+        """)
+
+        self.assertEqual(statement.statement_type, 'DROP')
+        self.assertTrue(statement.temporary)
+        self.assertFalse(statement.if_exists)
+        self.assertFalse(statement.dropped[0].database_name)
+        self.assertEqual(statement.dropped[0].table_name, 'test')
+
+    def test_drop_table_if_exists(self):
+        statement = drop_table_syntax.parseString("""
+        DROP TABLE IF EXISTS test;
+        """)
+
+        self.assertEqual(statement.statement_type, 'DROP')
+        self.assertFalse(statement.temporary)
+        self.assertTrue(statement.if_exists)
+        self.assertFalse(statement.dropped[0].database_name)
+        self.assertEqual(statement.dropped[0].table_name, 'test')

--- a/tests/grammar/test_rename_table.py
+++ b/tests/grammar/test_rename_table.py
@@ -1,0 +1,70 @@
+# -*- encoding:utf-8 -*-
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import unittest
+
+from mysqlparse.grammar.rename_table import rename_table_syntax
+
+
+class RenameTableSyntaxTest(unittest.TestCase):
+
+    def test_rename_table(self):
+        statement = rename_table_syntax.parseString("""
+        RENAME TABLE test1 TO test2;
+        """)
+
+        self.assertEqual(statement.statement_type, 'RENAME')
+        self.assertFalse(statement.table_renamed[0].old_database_name)
+        self.assertEqual(statement.table_renamed[0].old_table_name, 'test1')
+        self.assertFalse(statement.table_renamed[0].new_database_name)
+        self.assertEqual(statement.table_renamed[0].new_table_name, 'test2')
+
+    def test_rename_multiple_tables(self):
+        statement = rename_table_syntax.parseString("""
+        RENAME TABLE
+            test1 TO test2,
+            test3 TO test4,
+            test5 TO test6;
+        """)
+
+        self.assertEqual(statement.statement_type, 'RENAME')
+        self.assertFalse(statement.table_renamed[0].old_database_name)
+        self.assertEqual(statement.table_renamed[0].old_table_name, 'test1')
+        self.assertFalse(statement.table_renamed[0].new_database_name)
+        self.assertEqual(statement.table_renamed[0].new_table_name, 'test2')
+        self.assertFalse(statement.table_renamed[1].old_database_name)
+        self.assertEqual(statement.table_renamed[1].old_table_name, 'test3')
+        self.assertFalse(statement.table_renamed[1].new_database_name)
+        self.assertEqual(statement.table_renamed[1].new_table_name, 'test4')
+        self.assertFalse(statement.table_renamed[2].old_database_name)
+        self.assertEqual(statement.table_renamed[2].old_table_name, 'test5')
+        self.assertFalse(statement.table_renamed[2].new_database_name)
+        self.assertEqual(statement.table_renamed[2].new_table_name, 'test6')
+
+    def test_rename_database_table(self):
+        statement = rename_table_syntax.parseString("""
+        RENAME TABLE db1.test1 TO db2.test2;
+        """)
+
+        self.assertEqual(statement.statement_type, 'RENAME')
+        self.assertEqual(statement.table_renamed[0].old_database_name, 'db1')
+        self.assertEqual(statement.table_renamed[0].old_table_name, 'test1')
+        self.assertEqual(statement.table_renamed[0].new_database_name, 'db2')
+        self.assertEqual(statement.table_renamed[0].new_table_name, 'test2')
+
+    def test_rename_mixed_databases_tables(self):
+        statement = rename_table_syntax.parseString("""
+        RENAME TABLE
+            db1.test1 TO db2.test2,
+            test3 TO test4;
+        """)
+
+        self.assertEqual(statement.statement_type, 'RENAME')
+        self.assertEqual(statement.table_renamed[0].old_database_name, 'db1')
+        self.assertEqual(statement.table_renamed[0].old_table_name, 'test1')
+        self.assertEqual(statement.table_renamed[0].new_database_name, 'db2')
+        self.assertEqual(statement.table_renamed[0].new_table_name, 'test2')
+        self.assertFalse(statement.table_renamed[1].old_database_name)
+        self.assertEqual(statement.table_renamed[1].old_table_name, 'test3')
+        self.assertFalse(statement.table_renamed[1].new_database_name)
+        self.assertEqual(statement.table_renamed[1].new_table_name, 'test4')


### PR DESCRIPTION
Adds support for:
* `RENAME TABLE tbl_name TO new_tbl_name [, tbl_name2 TO new_tbl_name2] ...`
* `ALTER TABLE RENAME {INDEX|KEY} old_index_name TO new_index_name`
* `ALTER TABLE RENAME [TO|AS] new_tbl_name`

I took the liberty of moving `_database_name` from `mysqlparse.grammar.alter_table` to `mysqlparse.grammar.identifier` and renaming it to `database_name_syntax`. I'm open to putting it somewhere else or calling it something else, but it didn't make sense to import a private name from `alter_table.py` into `rename_table.py`. (And in fact, there are places it's not being used where MySQL *does* support having a database name, so it may be good to use it even more places.)

I don't really care about `ALTER TABLE RENAME {INDEX|KEY}`, but not including a way to parse these statements makes pyparsing throw a `ParserException` with a long and incomprehensible message (and a traceback that doesn't anywhere point to a line of code in the `mysqlparse` namespace) when [this precaution](https://github.com/seporaitis/mysqlparse/compare/master...jgysland:support-rename-table?expand=1#diff-4d5493d276fbc1ba528c2a8376444e1cR118) is taken and it attempts to parse `RENAME INDEX` or `RENAME KEY`.